### PR TITLE
Change discordeno target

### DIFF
--- a/cnames.ts
+++ b/cnames.ts
@@ -61,7 +61,7 @@ export default <CNAMEs> {
     target: "skillz4killz.github.io/gamer-landing",
   },
   "discordeno": {
-    target: "discordeno.github.io/discordeno",
+    target: "discordeno.github.io/guide",
   },
   "gamer": {
     target: "skillz4killz.github.io/gamer-deno",


### PR DESCRIPTION
We have moved our guide from our main repo (https://github.com/discordeno/discordeno) to a separate repo (https://github.com/discordeno/guide) and hope that our mod.land target could be changed correspondingly. 
This is the issue showing the change on our roadmap: https://github.com/discordeno/discordeno/issues/823

- [x] My submissions follows the [Submission Rules](http://mod.land/issues)
- [x] I have read and accepted the [Terms and Conditions](http://mod.land/tos)
