### PR TITLE
changes: janda.mod.land

### DIFF
--- a/cnames.ts
+++ b/cnames.ts
@@ -104,6 +104,7 @@ export default <CNAMEs> {
   },
   "janda": {
     target: "janda.up.railway.app",
+    proxied: false,
   },
   "keyv": {
     target: "tejasag.github.io/deno-keyv",


### PR DESCRIPTION
Hi, after applying custom mod.land subdomains on [railway](https://railway.app/) and this [docs](https://docs.railway.app/deploy/exposing-your-app#lets-encrypt-ssl-certificates), It is turn out into `ERR_TOO_MANY_REDIRECTS`
Could you try to disable `proxied` on janda.mod.land? Because mod.land has enabled for default, I forgot to set it off


- [x] My submissions follows the [Submission Rules](http://mod.land/issues)
- [x] I have read and accepted the [Terms and Conditions](http://mod.land/tos)
